### PR TITLE
Adicionando no CI permissão para publicar releases

### DIFF
--- a/codigo/Live280/exemplo_app/.github/workflows/ci.yaml
+++ b/codigo/Live280/exemplo_app/.github/workflows/ci.yaml
@@ -1,4 +1,8 @@
 name: CI
+
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Eu tinha visto isso no marketplace dessa action:

https://github.com/marketplace/actions/gh-release#permissions

Ela pode ajudar a quem for usar esse CI, não precisar adicionar a permissão de escrita manualmente